### PR TITLE
Added an export preset for Linux

### DIFF
--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -40,3 +40,29 @@ application/product_name="FunEmuStation Launcher"
 application/file_description="FunEmuStation - A simple but elegant launcher of emulators and pc games"
 application/copyright="2020 Danny Garay"
 application/trademarks=""
+
+[preset.1]
+
+name="Linux/X11"
+platform="Linux/X11"
+runnable=true
+custom_features=""
+export_filter="all_resources"
+include_filter="*.txt"
+exclude_filter=""
+export_path="bin/FunEmuStation_Launcher.x86_64"
+patch_list=PoolStringArray(  )
+script_export_mode=1
+script_encryption_key=""
+
+[preset.1.options]
+
+texture_format/bptc=false
+texture_format/s3tc=true
+texture_format/etc=false
+texture_format/etc2=false
+texture_format/no_bptc_fallbacks=true
+binary_format/64_bits=true
+binary_format/embed_pck=false
+custom_template/release=""
+custom_template/debug=""


### PR DESCRIPTION
It is already possible to startup the project via Godot using the repository but I thought it would be better to export it from source files. But it's necessary for Godots command line export functionality to have a preset in the export configuration.

So here is the merge request for this preset. I would maintain a package in the AUR for Arch linux as soon as this gets merged. ^^