### PR TITLE
Fix for paths on Unix based systems

### DIFF
--- a/global.gd
+++ b/global.gd
@@ -30,8 +30,8 @@ var data_path = ""
 
 func _enter_tree():
 	
-	#use a "data" folder relative to the user data
-	data_path = "user://fes_data"
+	#comprobar si existe una carpeta "data" dentro de la misma carpeta del ejecutable
+	data_path = OS.get_executable_path().get_base_dir()+"/fes_data"
 	#y crearla en caso de que no exista
 	if !dir.dir_exists(data_path):
 		dir.make_dir(data_path)

--- a/global.gd
+++ b/global.gd
@@ -30,8 +30,8 @@ var data_path = ""
 
 func _enter_tree():
 	
-	#comprobar si existe una carpeta "data" dentro de la misma carpeta del ejecutable
-	data_path = OS.get_executable_path().get_base_dir()+"/fes_data"
+	#use a "data" folder relative to the user data
+	data_path = "user://fes_data"
 	#y crearla en caso de que no exista
 	if !dir.dir_exists(data_path):
 		dir.make_dir(data_path)
@@ -125,8 +125,8 @@ func _enter_tree():
 		
 		#crear una carpeta "media" dentro del pathrom
 		#es en donde se guardaran los covers
-		if !dir.dir_exists(sys_data[s]["pathrom"]+"\\media"):
-			dir.make_dir(sys_data[s]["pathrom"]+"\\media")
+		if !dir.dir_exists(sys_data[s]["pathrom"]+"/media"):
+			dir.make_dir(sys_data[s]["pathrom"]+"/media")
 		
 		#recorrer los archivos validos, o sea las roms
 		idx_file = 0
@@ -135,9 +135,9 @@ func _enter_tree():
 			#nombre de archivo (sin su extensión)
 			var basename = v_fi.get_basename()
 			#ruta del cover del juego
-			var path_cover = sys_data[s]["pathrom"]+"\\media\\"+basename+".jpg"
+			var path_cover = sys_data[s]["pathrom"]+"/media/"+basename+".jpg"
 			#y del wallpaper
-			var path_wallpaper = sys_data[s]["pathrom"]+"\\media\\"+basename+"_bg.jpg"
+			var path_wallpaper = sys_data[s]["pathrom"]+"/media/"+basename+"_bg.jpg"
 			
 			#si el archivo tiene asociado un .jpg con su mismo nombre
 			#este es el cover
@@ -157,7 +157,7 @@ func _enter_tree():
 			#nombre,textura cover, textura wallpaper, ruta archivo
 			#ruta cover, ruta de wallpaper, key del sistema
 			systems_data_filtered[idx_sys].append([
-				basename,cover_texture,wallpaper_texture,sys_data[s]["pathrom"]+"\\"+v_fi,
+				basename,cover_texture,wallpaper_texture,sys_data[s]["pathrom"]+"/"+v_fi,
 				cover_texture,
 				wallpaper_texture,
 				s


### PR DESCRIPTION
I replaced all backslashes with slashes in used paths and I also replaced the relative path to the executable by the from Godot recommended [user data path](https://docs.godotengine.org/en/stable/tutorials/io/data_paths.html#user-path-persistent-data). So every configuration of the application will be relative to the user but the application itself can be installed system wide.

Otherwise the application has to be installed from every user separately because users generally don't have write or read access in system wide directories. So this should help a lot for packaging on Linux distros.